### PR TITLE
add docker configuration

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,7 +39,10 @@ Rails.application.configure do
     },
     port: ENV.fetch("SMTP_PORT") { 1025 }.to_i
   }
-  config.action_mailer.raise_delivery_errors = true # Recomendado para desarrollo para ver errores
+  config.action_mailer.raise_delivery_errors = true # Recommended for development to see errors
+
+  # Default URL options for Action Mailer (important for links in emails)
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
   # Make template changes take effect immediately.
   config.action_mailer.perform_caching = false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,14 +31,18 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  # Configure Action Mailer to use MailHog
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: ENV.fetch("SMTP_ADDRESS") {
+      "localhost"
+    },
+    port: ENV.fetch("SMTP_PORT") { 1025 }.to_i
+  }
+  config.action_mailer.raise_delivery_errors = true # Recomendado para desarrollo para ver errores
 
   # Make template changes take effect immediately.
   config.action_mailer.perform_caching = false
-
-  # Set localhost to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - SMTP_ADDRESS=mailhog
       - SMTP_PORT=1025
       - RAILS_ENV=development
+      - BUNDLE_WITHOUT="" # Ensure development gems are installed
       - RAILS_MASTER_KEY=${RAILS_MASTER_KEY}
     volumes:
       - .:/rails

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  web:
+    build: .
+    ports:
+      - "3000:80"
+    environment:
+      - SMTP_ADDRESS=mailhog
+      - SMTP_PORT=1025
+      - RAILS_ENV=development
+      - RAILS_MASTER_KEY=${RAILS_MASTER_KEY}
+    volumes:
+      - .:/rails
+      - bundle_cache:/usr/local/bundle
+      - sqlite_data:/rails/db
+    stdin_open: true
+    tty: true
+    command: ["./bin/rails", "server", "-b", "0.0.0.0", "-p", "80"]
+    depends_on:
+      - mailhog
+
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - "1025:1025" # SMTP port
+      - "8025:8025" # Web UI port
+
+volumes:
+  sqlite_data:
+  bundle_cache:


### PR DESCRIPTION
In order to configure email sending to confirm the email address is authentic when the user creates a new account, it will be necessary to install a test SMTP server.
It will also be necessary in case the user has forgotten their password or wants to change it.
For this reason, I installed the Mailhog test SMTP server under Docker.

MailHog (Web Interface for Emails): http://localhost:8025
